### PR TITLE
Includes TFs in hub.txt

### DIFF
--- a/python/render/templates/hub.j2
+++ b/python/render/templates/hub.j2
@@ -1,6 +1,6 @@
 hub {{ hub.name }}
 shortLabel {{ hub.short_label }}
-longLabel {{ hub.long_label }}
+longLabel {{ hub.long_label.prefix }} {{ hub.long_label.tfs|join(', ')}}, {{ hub.long_label.suffix }}
 genomesFile {{ hub.genomes_file | default('genomes.txt') }}
 email {{ hub.email }}
 descriptionUrl {{ hub.description_url | default('http://www.genome.duke.edu') }}

--- a/yaml/hub/hub.yaml
+++ b/yaml/hub/hub.yaml
@@ -1,5 +1,10 @@
 hub:
   name: DukeGCBHub_TFDNA
   short_label: Duke GCB - TF-DNA Binding Predictions
-  long_label:  Predictions of in vitro TF-DNA binding levels, according to SVR models trained on gcPBM data
+  long_label:
+    prefix: Predictions of in vitro TF-DNA binding levels on
+    tfs:
+      - E2F1
+      - E2F4
+    suffix: according to SVR models trained on gcPBM data
   email: gcb-contact@duke.edu


### PR DESCRIPTION
TFs are listed in the YAML for the hub, but now also listed in Makefile.hub and Makefile.bigbed.

Need to centralize this listing for scalability - either abandon the makefiles or get better at makefiles.

Fixes #4
